### PR TITLE
Update lubridate to fix chapter structure

### DIFF
--- a/lubridate.Rmd
+++ b/lubridate.Rmd
@@ -86,12 +86,13 @@ df <- read_csv("data/weather_kiel_holtenau.csv",
 df$MESS_DATUM <- parse_date_time(df$MESS_DATUM, orders ="Ymd HM")
 head(df)
 ```
-# Evt. TODO - Ergänzung bzw. Alternativen mit S3 (baseR) Funktionen
-# strftime(Sys.time(), "%Y%m%d%H%M")
-# return character
-# strptime(df$MESS_DATUM, "%Y%m%d%H%M")
-# strptime(Sys.time(), "%Y%m%d%H%M")
-# return list
+
+> Evt. TODO - Ergänzung bzw. Alternativen mit S3 (baseR) Funktionen
+> strftime(Sys.time(), "%Y%m%d%H%M")
+> return character
+> strptime(df$MESS_DATUM, "%Y%m%d%H%M")
+> strptime(Sys.time(), "%Y%m%d%H%M")
+> return list
 
 OK we have successfully formated the time-stamp data into a productive format. The next steps are a check and elimination procedure to eliminate missing values (NAs) from the dataset, 
 if some observations might have failed to generate data successfully.


### PR DESCRIPTION
Moin Marcus und Robert,

eure letzte Änderun hat die Kapitelstruktur des Buches ein wenig durcheinandergewürfelt, da ihr für euch als Merkposten ein paar Bulletpoints mit dem # Symbol eingefügt hattet. Markdown erstellt daraus aber jeweils neue Kapitelüberschriften. 

Das sah mir etwas zu kryptisch aus :-) Daher nun mein Pull Request, der wieder die alte Struktur widerherstellt. 

VG, Till